### PR TITLE
fix: read kubeconfig from env variable

### DIFF
--- a/app/cmd/nodes/nodes.go
+++ b/app/cmd/nodes/nodes.go
@@ -50,13 +50,14 @@ func init() {
 }
 
 func fetchNodes(cmd *cobra.Command, args []string) {
-	// Create a Kubernetes clientset
-	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
-
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 	if err != nil {
-		fmt.Printf("Failed to create config: %v\n", err)
-		return
+		return err
+	}
+
+	restConfig, err := clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return err
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
Current code reads kube config from $HOME/.kube/config but users/tools can often specify their kube configs by setting the `KUBECONFIG` env variable. 

This PR reads kube config from `KUBECONFIG` variable and falls back to `$HOME/.kube/config` if the env variable is not set.